### PR TITLE
use host to correct path for connect requests

### DIFF
--- a/normalize_test.go
+++ b/normalize_test.go
@@ -146,6 +146,11 @@ func TestNormalizeRequest(t *testing.T) {
 			"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",
 			false,
 		}, {
+			"correct URI with host for CONNECT",
+			"CONNECT / HTTP/1.1\r\nHost: www.google.com\r\n\r\n",
+			"CONNECT www.google.com:80 HTTP/1.1\r\nHost: www.google.com\r\n\r\n",
+			false,
+		}, {
 			"clean header",
 			"GET / HTTP/1.1\r\nHost: \r example.com\r\n\r\n",
 			"GET / HTTP/1.1\r\nHost: example.com\r\n\r\n",


### PR DESCRIPTION
The path of the request line for CONNECT requests is supposed be host:port. This added a check if the path defaulted to '/' when failing to normalize it and sets it to host:port for CONNECT requests.